### PR TITLE
Fix #1: correct off-by-one error in collection_name property.

### DIFF
--- a/edr_query_parser/edr_query_parser.py
+++ b/edr_query_parser/edr_query_parser.py
@@ -26,9 +26,10 @@ class EDRQueryParser:
 
     @property
     def collection_name(self):
-        if len(self.url_parts) != self.url_parts.index('collections') + 2:
+        try:
             return self.url_parts[self.url_parts.index('collections') + 1]
-        raise ValueError('collection name not found in url')
+        except (ValueError, IndexError):
+            raise ValueError('collection name not found in url')
 
     @property
     def query_type(self):

--- a/edr_query_parser/tests/test_edr_query_parser.py
+++ b/edr_query_parser/tests/test_edr_query_parser.py
@@ -7,8 +7,8 @@ from dateutil.parser import isoparse
     ('https://somewhere.com/collections/my_collection/corridor?', 'my_collection'),
     ('https://somewhere.com/collections/collections/position?', 'collections'),
     ('https://somewhere.com/collections/observations/position?', 'observations'),
-    ('https://somewhere.com/collections/position?', 'collection name not found in url'),
-    ('https://somewhere.com/collections/items?', 'collection name not found in url'),
+    ('https://somewhere.com/collections', 'collection name not found in url'),
+    ('https://somewhere.com/items/my_collection', 'collection name not found in url'),
 ])
 def test_collection_name(url, expected):
     edr = EDRQueryParser(url)


### PR DESCRIPTION
Fixes [#1 ](https://github.com/r0w4n/edr_query_parser/issues/1)

- Remove two tests because collection name is always the URL part after
  "/collections". (We cannot tell the difference between a collection
  called "items" and a malformed URL with the collection ID missing.)
- Ensure that we get a ValueError instead of an IndexError when there is
  no collection ID or "/collections" is missing.


There is a behaviour change here: previously, putting one of the EDR query types after `collections/` would produce a `ValueError`. Now it does not, because we can't tell the difference between, e.g.  a collection named 'items' and a URL missing its collection ID.