### PR TITLE
fix for '+' character in query string

### DIFF
--- a/edr_query_parser/edr_query_parser.py
+++ b/edr_query_parser/edr_query_parser.py
@@ -119,10 +119,6 @@ class EDRQueryParser:
         return Parameter(self.query_parts.get('next'))
 
     @property
-    def next_unquote(self):
-        return Parameter(self.query_parts_unquote.get('next'))
-
-    @property
     def limit(self):
         return ParameterInt(self.query_parts.get('limit'))
 

--- a/edr_query_parser/tests/test_edr_query_parser.py
+++ b/edr_query_parser/tests/test_edr_query_parser.py
@@ -491,6 +491,14 @@ def test_datetime_greater_than(url, expected):
 
 
 @pytest.mark.parametrize("url, expected", [
+    ('https://somewhere.com/collections/my_collection/items?next=token123++dsfas&param1=apple%20+%20banana', 'token123++dsfas'),
+    ('https://somewhere.com/collections/my_collection/items?next=apple%20+%20banana', 'apple + banana'),
+    ('https://somewhere.com/collections/my_collection/items?next=%20', ' '),
+    ('https://somewhere.com/collections/my_collection/items?next=+', '+'),
+    ('https://somewhere.com/collections/my_collection/items?next=""', '""'),
+    ('https://somewhere.com/collections/my_collection/items?next="', '"'),
+    ("https://somewhere.com/collections/my_collection/items?next=''", "''"),
+    ("https://somewhere.com/collections/my_collection/items?next='", "'"),
     ('https://somewhere.com/collections/my_collection/items?next=token123', 'token123'),
     ('https://somewhere.com/collections/my_collection/items?next=', None),
     ('https://somewhere.com/collections/my_collection/items', None)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="edr query parser",
-    version="2.7",
+    version="2.8",
     author="r0w4n",
     author_email="r0w4n@nuisance.com",
     description="Environmental data retrieval API query parser",


### PR DESCRIPTION
Fix issue for dropping out '+' character contain in 'next' query parameter. This special character is retrieved from boto3 pagination token and need to be preserved as it is.  